### PR TITLE
Backwards compatible fix for deprecated security.context service

### DIFF
--- a/DependencyInjection/Compiler/SecurityCompilerPass.php
+++ b/DependencyInjection/Compiler/SecurityCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SecurityCompilerPass implements CompilerPassInterface
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        /**
+         * Use \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage if it exists
+         */
+        if ($container->hasDefinition('security.token_storage')) {
+            $container->setDefinition('jmikola_auto_login.token_storage_or_security_context', $container->getDefinition('security.token_storage'));
+        } else {
+            $container->setDefinition('jmikola_auto_login.token_storage_or_security_context', $container->getDefinition('security.context'));
+        }
+    }
+}

--- a/JmikolaAutoLoginBundle.php
+++ b/JmikolaAutoLoginBundle.php
@@ -2,6 +2,7 @@
 
 namespace Jmikola\AutoLoginBundle;
 
+use Jmikola\AutoLoginBundle\DependencyInjection\Compiler\SecurityCompilerPass;
 use Jmikola\AutoLoginBundle\DependencyInjection\Security\AutoLoginFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -14,6 +15,8 @@ class JmikolaAutoLoginBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
+        $container->addCompilerPass(new SecurityCompilerPass());
 
         $extension = $container->getExtension('security');
         $extension->addSecurityListenerFactory(new AutoLoginFactory());

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="jmikola_auto_login.security.authentication.listener" class="%jmikola_auto_login.security.authentication.listener.class%" abstract="true" public="false">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="jmikola_auto_login.token_storage_or_security_context" />
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared key -->
             <argument /> <!-- Token query parameter -->


### PR DESCRIPTION
Use \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage if it exists or fall back on the security.context

composer.json should have a dependency on a newer jmikola/auto-login package, for which I created a pull request too