### PR TITLE
Support security.token_storage service in Symfony 2.6+

### DIFF
--- a/DependencyInjection/Security/AutoLoginFactory.php
+++ b/DependencyInjection/Security/AutoLoginFactory.php
@@ -26,9 +26,15 @@ class AutoLoginFactory implements SecurityFactoryInterface
             $provider->addArgument(new Reference($config['auto_login_user_provider']));
         }
 
+        // Fall back to security.context service for BC with Symfony <2.6
+        $tokenStorageReference = interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+            ? new Reference('security.token_storage')
+            : new Reference('security.context');
+
         $listenerId = 'jmikola_auto_login.security.authentication.listener.'.$id;
         $container
             ->setDefinition($listenerId, new DefinitionDecorator('jmikola_auto_login.security.authentication.listener'))
+            ->replaceArgument(0, $tokenStorageReference)
             ->replaceArgument(2, $id)
             ->replaceArgument(3, $config['token_param'])
             ->replaceArgument(6, array(

--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="jmikola_auto_login.security.authentication.listener" class="%jmikola_auto_login.security.authentication.listener.class%" abstract="true" public="false">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context" />
+            <argument /> <!-- security.token_storage or security.context for Symfony <2.6 -->
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared key -->
             <argument /> <!-- Token query parameter -->

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/dependency-injection": "~2.1",
         "symfony/http-kernel": "~2.1",
         "symfony/security-bundle": "~2.1",
-        "jmikola/auto-login": "~1.2"
+        "jmikola/auto-login": "^1.2.2"
     },
     "autoload": {
         "psr-0": { "Jmikola\\AutoLoginBundle": "" }


### PR DESCRIPTION
Supersedes #11 and supports jmikola/AutoLogin#13.