### PR TITLE
Allow compatibility with Symfony 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JmikolaAutoLoginBundle
 
-This bundle integrates the [AutoLogin][] library with Symfony2, which implements
+This bundle integrates the [AutoLogin][] library with Symfony, which implements
 a security firewall listener to authenticate users based on a single query
 parameter. This is useful for providing one-click login functionality in email
 and newsletter links.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jmikola/auto-login-bundle",
     "type": "symfony-bundle",
-    "description": "Authenticate users in your Symfony2 app via a single query parameter (e.g. email and newsletter links).",
+    "description": "Authenticate users in your Symfony app via a single query parameter (e.g. email and newsletter links).",
     "keywords": ["authentication", "auto-login", "login", "security"],
     "homepage": "https://github.com/jmikola/JmikolaAutoLoginBundle",
     "license": "MIT",
@@ -10,11 +10,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/config": "~2.1",
-        "symfony/dependency-injection": "~2.1",
-        "symfony/http-kernel": "~2.1",
-        "symfony/security-bundle": "~2.1",
-        "jmikola/auto-login": "^1.2.2"
+        "symfony/config": "^2.2 || ^3.0",
+        "symfony/dependency-injection": "^2.2 || ^3.0",
+        "symfony/http-kernel": "^2.2 || ^3.0",
+        "symfony/security-bundle": "^2.2 || ^3.0",
+        "jmikola/auto-login": "^1.2.3"
     },
     "autoload": {
         "psr-0": { "Jmikola\\AutoLoginBundle": "" }


### PR DESCRIPTION
As requested in #17 and https://github.com/jmikola/AutoLogin/issues/16.

This PR simply relaxes the `composer.json` requirements to allow for Symfony 3.0. AFAIK, all necessary code changes are the in library: https://github.com/jmikola/AutoLogin/pull/18