### PR TITLE
Added tests to make sure the bundle works with different symfony versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
+phpunit.xml
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+language: php
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+env:
+    global:
+        - TEST_COMMAND="phpunit"
+    matrix:
+        - SYMFONY_VERSION=2.8.*
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: hhvm
+        - env: SYMFONY_VERSION=3.0.*
+
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_VERSION=2.1.* COVERAGE=true TEST_COMMAND="phpunit --coverage-text --coverage-clover=build/coverage.xml"
+        - php: 5.6
+          env: SYMFONY_VERSION=2.1.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.3.*
+        - php: 5.6
+          env: SYMFONY_VERSION=2.7.*
+        - php: 5.6
+          env: SYMFONY_VERSION=3.0.*
+
+before_install:
+    - travis_retry composer self-update
+
+install:
+    - composer require symfony/config:${SYMFONY_VERSION} symfony/ependency-injection:${SYMFONY_VERSION} symfony/http-kernel:${SYMFONY_VERSION} symfony/security-bundle:${SYMFONY_VERSION} --no-update
+    - composer update ${COMPOSER_FLAGS} --prefer-source --no-interaction
+
+script:
+    - $TEST_COMMAND
+
+after_success:
+    - if [[ "$COVERAGE" = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+    - if [[ "$COVERAGE" = true ]]; then php ocular.phar code-coverage:upload --format=php-clover build/coverage.xml; fi

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\Tests\Functional;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
+
+class AppKernel extends Kernel
+{
+    private $config;
+
+    public function __construct($config)
+    {
+        parent::__construct('test', true);
+        
+        $fs = new Filesystem();
+        if (!$fs->isAbsolutePath($config)) {
+            $config = __DIR__.'/config/'.$config;
+        }
+        
+        if (!file_exists($config)) {
+            throw new \RuntimeException(sprintf('The config file "%s" does not exist.', $config));
+        }
+        
+        $this->config = $config;
+    }
+
+    public function registerBundles()
+    {
+        return array(
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new \Jmikola\AutoLoginBundle\JmikolaAutoLoginBundle(),
+            new \Jmikola\AutoLoginBundle\Tests\Functional\TestBundle\TestBundle(),
+        );
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load($this->config);
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/JmikolaAutoLoginBundle';
+    }
+
+    public function serialize()
+    {
+        return $this->config;
+    }
+
+    public function unserialize($config)
+    {
+        $this->__construct($config);
+    }
+}

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class BaseTestCase extends WebTestCase
+{
+    protected static function createKernel(array $options = array())
+    {
+        return new AppKernel(isset($options['config']) ? $options['config'] : 'default.yml');
+    }
+}

--- a/Tests/Functional/BundleInitializationTest.php
+++ b/Tests/Functional/BundleInitializationTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\Tests\Functional;
+
+class BundleInitializationTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function bundle_will_install_with_no_errors()
+    {
+        static::createClient();
+    }
+}

--- a/Tests/Functional/TestBundle/Service/AcmeAutoLoginUserProvider.php
+++ b/Tests/Functional/TestBundle/Service/AcmeAutoLoginUserProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\Tests\Functional\TestBundle\Service;
+
+use Jmikola\AutoLogin\User\AutoLoginTokenNotFoundException;
+use Jmikola\AutoLogin\User\AutoLoginUserProviderInterface;
+use Jmikola\AutoLogin\User\UserInterface;
+
+class AcmeAutoLoginUserProvider implements AutoLoginUserProviderInterface
+{
+    public function loadUserByAutoLoginToken($key)
+    {
+        throw new \Jmikola\AutoLogin\Exception\AutoLoginTokenNotFoundException();
+    }
+}

--- a/Tests/Functional/TestBundle/TestBundle.php
+++ b/Tests/Functional/TestBundle/TestBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\Tests\Functional\TestBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestBundle extends Bundle
+{
+}

--- a/Tests/Functional/config/default.yml
+++ b/Tests/Functional/config/default.yml
@@ -1,0 +1,16 @@
+imports:
+    - { resource: framework.yml }
+
+services:
+  acme.auto_login_user_provider:
+    class: Jmikola\AutoLoginBundle\Tests\Functional\TestBundle\Service\AcmeAutoLoginUserProvider
+
+security:
+  providers:
+    in_memory:
+      memory: ~
+
+  firewalls:
+    main:
+      jmikola_auto_login:
+        auto_login_user_provider: acme.auto_login_user_provider

--- a/Tests/Functional/config/framework.yml
+++ b/Tests/Functional/config/framework.yml
@@ -1,0 +1,11 @@
+framework:
+    secret: test
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    form: false
+    csrf_protection: false
+    validation:
+        enabled: false
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"

--- a/Tests/Unit/DependencyInjection/JmikolaAutoLoginExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/JmikolaAutoLoginExtensionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jmikola\AutoLoginBundle\Tests\Unit\DependencyInjection;
+
+use Jmikola\AutoLoginBundle\DependencyInjection\JmikolaAutoLoginExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+class JmikolaAutoLoginExtensionTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions()
+    {
+        return array(
+            new JmikolaAutoLoginExtension()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function after_loading_services_will_exist()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasService('jmikola_auto_login.security.authentication.provider', 'Jmikola\AutoLogin\Authentication\Provider\AutoLoginProvider');
+        $this->assertContainerBuilderHasService('jmikola_auto_login.security.authentication.listener', 'Jmikola\AutoLogin\Http\Firewall\AutoLoginListener');
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('jmikola_auto_login.security.authentication.listener', 'monolog.logger', array('channel'=>'security'));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,12 @@
         "symfony/security-bundle": "~2.1",
         "jmikola/auto-login": "^1.2.2"
     },
+    "require-dev": {
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+        "symfony/framework-bundle": "^2.1|^3.0",
+        "symfony/filesystem": "^2.1|^3.0",
+        "symfony/browser-kit": "^2.1|^3.0"
+    },
     "autoload": {
         "psr-0": { "Jmikola\\AutoLoginBundle": "" }
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This PR adds functional tests and unit tests. Together with the .travis.yml we will make sure that the bundle can be enabled and works on different Symfony versions. 

I test SF2.8 with all supported php versions and then I test symfony versions 2.1, 2.3, 2.7 and 3.0. 